### PR TITLE
Cleanup and Fixup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,18 +11,6 @@ RUN pip install Pillow numpy scipy matplotlib
 
 RUN mkdir -p /opt/al_support
 
-# Download the support files from Amazon S3
-RUN wget -O /tmp/exiftool.tar.gz https://exiftool.org/Image-ExifTool-11.96.tar.gz
-RUN tar -xvf /tmp/exiftool.tar.gz -C /opt/al_support
-
-# Run installation
-WORKDIR /opt/al_support/Image-ExifTool-11.96
-RUN perl ./Makefile.PL
-RUN make install
-
-# Cleanup
-RUN rm -rf /tmp/*
-
 # Switch to assemblyline user
 USER assemblyline
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ USER root
 
 # Get required apt packages
 # Image/Science libraries for Python & Tesseract OCR engine/ Language plug-ins
-RUN apt-get update && apt-get install -y make perl libjpeg-dev imagemagick wget tar tesseract-ocr tesseract-ocr-all && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libjpeg-dev zlib1g-dev imagemagick tesseract-ocr tesseract-ocr-all && rm -rf /var/lib/apt/lists/*
 RUN pip install Pillow numpy scipy matplotlib
 
 RUN mkdir -p /opt/al_support

--- a/README.md
+++ b/README.md
@@ -6,26 +6,13 @@ image analysis.
 **NOTE**: This service does not require you to buy any licence and is
 preinstalled and working after a default installation
 
-# Applications
-
-## Exiftool
-
-ExifTool is a platform-independent Perl library plus a command-line application for reading, writing and editing meta 
-information in a wide variety of files.
-
-The program is found here: https://www.sno.phy.queensu.ca/~phil/exiftool/ 
-
 File types currently supported:
 
 - audiovisual/*
-- document/pdf
 - image/*
 
-AL Outputs:
 
-- Extracts metadata information and tags. 
-
-- Binary output extracted to file
+# Applications
 
 ## PIL library
 
@@ -33,7 +20,7 @@ Python library
 
 AL Outputs:
 
-- Basic image information (sometimes differs from Exiftool's output)
+- Basic image information
 
 ## Tesseract
 

--- a/pixaxe/pixaxe.py
+++ b/pixaxe/pixaxe.py
@@ -189,40 +189,6 @@ class Pixaxe(ServiceBase):
                     return leftovers
         return
 
-    def call_exiftools(self, infile):
-        """Runs command-line tool Exiftools. Arguments:
-         -ee Extract information from embedded files
-         -G Print group name for each tag
-         -m Ignore minor errors and warnings
-         -q Quiet processing
-         -t Tab separated
-         -x TAG Exclude specified file TAGs
-         --PDF:* Exlude PDF parser (timeouts)
-
-        Args:
-            infile: File path.
-
-        Returns:
-            Standard output and error output of command.
-        """
-        cmd = ["exiftool", "-a", "-ee", "-G", "-m", "-t", "-x", "Directory", "-x", "File*", "-x", "MIMEType", '--PDF:*',
-               infile]
-        return self.process(command=cmd, name="exiftool")
-
-    def call_exiftools_extract(self, infile, k):
-        """Runs command-line tool Exiftools to extract binary metadata. Arguments:
-         -b Binary output
-         -{} item to extract
-        Args:
-            infile: File path.
-            k: String of metadata item to extract.
-
-        Returns:
-            Standard output and error output of command.
-        """
-        cmd = ["exiftool", "-b", "-{}".format(k.replace(' '.encode(), "".encode())), infile]
-        return self.process(command=cmd, name="exiftool extract")
-
     def tesseract_call(self, infile, outfile):
         """Runs command-line tool Tesseract. Arguments:
 
@@ -329,88 +295,6 @@ class Pixaxe(ServiceBase):
         run_steg = request.get_param('run_steg')
 
         bin_extracted = set()
-
-        # Attempt to scan file with exiftool and extract any binary data in meta that is over 50 bytes.
-        stdout, stderr = self.call_exiftools(infile)
-        file_info = {}
-
-        t_encoded = b"\t"
-        if stdout:
-            for li in stdout.split(b"\n"):
-                if t_encoded in li:
-                    if li.split(t_encoded)[2]:
-                        if self.getfromdict(file_info, [li.split(t_encoded)[0]]):
-                            self.setindict(file_info, [li.split(t_encoded)[0], li.split(t_encoded)[1]],
-                                           li.split(t_encoded)[2])
-                        else:
-                            self.setindict(file_info, [li.split(t_encoded)[0]],
-                                           {li.split(t_encoded)[1]: li.split(t_encoded)[2]})
-            # Extract any binary information over 50 bytes
-            for k, i in iter(file_info.items()):
-                for sk, si in iter(i.items()):
-                    if si.startswith(b"(Binary data"):
-                        bresult, stderr = self.call_exiftools_extract(infile, sk)
-                        if bresult:
-                            binhash = hashlib.sha256(bresult).hexdigest()
-                            if binhash in bin_extracted:
-                                continue
-                            bin_extracted.add(binhash)
-                            # space\carraige return\new line\null\0
-                            if len(bresult.rstrip(b'0 \t\r\n\0')) < 50:
-                                continue
-                            file_name = "{}_binary_meta".format(binhash[0:10])
-                            file_path = os.path.join(self.working_directory, file_name)
-                            request.add_extracted(file_path, file_name, "Extracted binary data from ExifTools output.")
-                            with open(file_path, 'wb') as unibu_file:
-                                unibu_file.write(bresult)
-
-            if not stderr:
-                trv_dic = True
-                if len(file_info.keys()) == 1:
-                    if list(file_info.keys())[0].upper() == 'EXIFTOOL':
-                        trv_dic = False
-                if trv_dic:
-                    eres = (ResultSection("ExifTools Results", body_format=BODY_FORMAT.MEMORY_DUMP))
-                    exif_res = (ResultSection("File Info:", body_format=BODY_FORMAT.MEMORY_DUMP,
-                                              parent=eres))
-                    recognized_ftype = True
-                    for k, i in iter(file_info.items()):
-                        ku = k.decode().upper()
-                        subexi_res = (ResultSection("::{} DATA::".format(ku),
-                                                    body_format=BODY_FORMAT.MEMORY_DUMP, parent=exif_res))
-                        meta_list = []
-                        for lk, li in iter(i.items()):
-                            # Output for unknown file type will not go to stderr
-                            if ku == "EXIFTOOL" and li == 'Unknown file type':
-                                recognized_ftype = False
-                                self.log.debug('File type for sample {} not supported by EXIFTOOLS'.format(self.sha))
-                                continue
-                            lku = lk.decode().upper()
-                            mvalue = '{0}: {1}'.format(lk.decode(), li.decode())
-                            subexi_res.add_line(mvalue)
-                            # Take out dates from meta hash (calculated below)
-                            if 'date' not in mvalue.lower():
-                                meta_list.append(mvalue)
-                            # Look for specific metadata to tag
-                            if ku == "COMPOSITE":
-                                if lku == "MEGAPIXELS":
-                                    exif_res.add_tag("file.img.mega_pixels",
-                                                     li)
-                            if ku == "XMP":
-                                if lku in self.XMP_TAGGED_VALUES:
-                                    field = self.XMP_TAGGED_VALUES[lku].replace("XMP_", "").lower()
-                                    exif_res.add_tag("file.img.exif_tool.{}".format(field),
-                                                     li)
-                        # Create a hash of each metadata section
-                        if ku not in ["COMPOSITE", "EXIFTOOL"]:
-                            meta_list.sort()
-                            joined_list = (" ".join(meta_list)).encode()
-                            meta_hash = hashlib.sha1(joined_list).hexdigest()
-                            exif_res.add_tag("file.img.sorted_metadata_hash",
-                                             "{}:{}".format(ku, meta_hash))
-
-                    if recognized_ftype:
-                        result.add_section(eres)
 
         # Run image-specific modules
         supported_images = re.compile('image/(bmp|gif|jpeg|jpg|png)')

--- a/pixaxe/pixaxe.py
+++ b/pixaxe/pixaxe.py
@@ -294,8 +294,6 @@ class Pixaxe(ServiceBase):
         infile = request.file_path
         run_steg = request.get_param('run_steg')
 
-        bin_extracted = set()
-
         # Run image-specific modules
         supported_images = re.compile('image/(bmp|gif|jpeg|jpg|png)')
         if re.match(supported_images, request.file_type):
@@ -349,7 +347,6 @@ class Pixaxe(ServiceBase):
                 ores.add_line("Text preview (up to 500 bytes):\n")
                 ores.add_line("{}".format(usable_out[0:500]))
                 result.add_section(ores)
-
             # Find attached data
             additional_content = self.find_additional_content(infile)
             if additional_content:
@@ -365,7 +362,6 @@ class Pixaxe(ServiceBase):
                 request.add_extracted(file_path, file_name, "Carved content found at end of image.")
                 with open(file_path, 'wb') as unibu_file:
                     unibu_file.write(additional_content)
-
             # Steganography modules
             if decloak:
                 if request.deep_scan:

--- a/pixaxe/steg.py
+++ b/pixaxe/steg.py
@@ -88,7 +88,7 @@ class ImageInfo(object):
         except Exception:
             raise NotSupported()
 
-        self.binary_pixels = self.convert_binary_string(self.imode, self.channels_to_process, self.ipixels)
+        self.binary_pixels = [self.convert_binary_string(self.imode, self.channels_to_process, self.ipixels)]
         self.pixel_count = (self.isize[0] * self.isize[1] * self.channels_to_process)
 
         # Chunk size equals (#bytes*8) bits/num byte-values per pixel. Therefore if 8 bits per pixel, and you want to
@@ -111,10 +111,9 @@ class ImageInfo(object):
     @staticmethod
     def convert_binary_string(mode, channels, p):
 
-        bplist = []
         if channels == 1:
             for pi in p:
-                bplist.append('{0:08b}'.format(pi))
+                yield '{0:08b}'.format(pi)
 
         else:
             for pi in p:
@@ -123,8 +122,7 @@ class ImageInfo(object):
                     pset += ('{0:08b}'.format(ip),)
                 if mode == 'RGBA':
                     pset += ('{0:08b}'.format(pi[-1]),)
-                bplist.append(pset)
-        return bplist
+                yield pset
 
     @staticmethod
     def extract_pixels(i):

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -27,11 +27,6 @@ submission_params:
     value: false
 
 heuristics:
-  - heur_id: 1
-    name: Exiftool binary extract
-    score: 10
-    filetype: text/plain
-    description: Over 50 bytes extracted from Exiftool output
   - heur_id: 2
     name: Appended image data
     score: 10

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -2,7 +2,7 @@ name: Pixaxe
 version: $SERVICE_TAG
 description: >-
   Image examination
-accepts: document/pdf|image/.*|audiovisual/.*
+accepts: image/.*|audiovisual/.*
 rejects: empty|metadata/.*
 
 stage: CORE


### PR DESCRIPTION
Removed PDF analysis from service since Characterize already does it.

Fixed memory issue that was causing the containers to crash when dealing with an image > 8MB.