### PR TITLE
Pass service logger to supporting libs

### DIFF
--- a/pixaxe/pixaxe.py
+++ b/pixaxe/pixaxe.py
@@ -1,4 +1,9 @@
-import hashlib, magic, os, re, struct, subprocess
+import hashlib
+import magic
+import os
+import re
+import struct
+import subprocess
 from pixaxe.steg import ImageInfo, NotSupported
 
 from assemblyline_v4_service.common.base import ServiceBase
@@ -127,7 +132,7 @@ class Pixaxe(ServiceBase):
             jtype = data[20:24]
             if jtype in ftyps:
                 file_type = ftyps[jtype]
-                print(file_type)
+                self.log.debug(file_type)
             else:
                 return
             while True:
@@ -303,7 +308,7 @@ class Pixaxe(ServiceBase):
             else:
                 decloak = False
             try:
-                imginfo = ImageInfo(infile, request, result, self.working_directory)
+                imginfo = ImageInfo(infile, request, result, self.working_directory, self.log)
             except NotSupported:
                 decloak = False
 

--- a/pixaxe/steg.py
+++ b/pixaxe/steg.py
@@ -17,11 +17,12 @@ class NotSupported(Exception):
 
 
 class ImageInfo(object):
-    def __init__(self, i, request=None, result=None, working_directory=None):
+    def __init__(self, i, request=None, result=None, working_directory=None, logger=None):
 
         self.request = request
         self.result = result
         self.working_directory = working_directory
+        self.log = logger
 
         if result:
             self.working_result = (ResultSection("Image Steganography Module Results:",
@@ -57,10 +58,10 @@ class ImageInfo(object):
 
         if self.imode.upper() not in supported_modes:
             if not self.result:
-                print("{} image mode not currently supported for steganlaysis modules".format(self.imode))
+                self.log.warning("{} image mode not currently supported for steganlaysis modules".format(self.imode))
                 exit()
             else:
-                print("not a supported mode: {}".format(self.result))
+                self.log.warning("not a supported mode: {}".format(self.result))
                 raise NotSupported()
         else:
             self.channels_to_process = supported_modes[self.imode]
@@ -263,7 +264,7 @@ class ImageInfo(object):
             # If greyscale, only one set of pixels to process
             if self.channels_to_process == 1:
                 while len(pixels) != 0:
-                    print(len(pixels))
+                    self.log.debug(len(pixels))
                     # In bytes
                     x_location = (self.chunk * self.channels_to_process) * index / 8
                     x_points.append(x_location)
@@ -700,7 +701,7 @@ class ImageInfo(object):
                                                                  body_format=BODY_FORMAT.MEMORY_DUMP,
                                                                  body=final_body))
             else:
-                print("\t {}".format(final_body))
+                self.log.info("\t {}".format(final_body))
 
         return
 


### PR DESCRIPTION
Related: https://cccs.atlassian.net/browse/AL-1103

One among other services that have libraries that print to stdout or stderr. This results in extra logs that may or may not be needed in production deployments.

Example:
Pixaxe printed '1' over 600K times, this kind of information provides no value and bypasses our log_level setting of warning+ in our deployments.